### PR TITLE
CMake: Reference libtestbmifortranmodel.so as a target, rather than a file path

### DIFF
--- a/SCHISM_BMI/CMakeLists.txt
+++ b/SCHISM_BMI/CMakeLists.txt
@@ -238,16 +238,13 @@ install(TARGETS testbmifortranmodel
 
 
 set(BMI_INCLUDE "${PROJECT_SOURCE_DIR}/build/fortran")
-set(BMI_LIB "${PROJECT_SOURCE_DIR}/build/libtestbmifortranmodel.so")
 
 include_directories(${BMI_INCLUDE})
-link_directories(${BMI_LIB})
-
 
 add_executable(schism_driver src/schism_bmi_driver_test.f90)
 
 #add_dependencies(schism_driver ${NetCDFLIBS} parmetis)
 
-target_link_libraries(schism_driver PUBLIC ${BMI_LIB} ${NetCDFLIBS} parmetis)
+target_link_libraries(schism_driver PUBLIC ${NetCDFLIBS} parmetis testbmifortranmodel)
 
 install(TARGETS schism_driver DESTINATION ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
This allows building in an arbitrary directory without CMake getting confused. It also allows just saying `make schism_driver` without having to manually `make testbmifortranmodel` first, since CMake knows about the dependency now.